### PR TITLE
Allow setting uname externally to allow cross compilation

### DIFF
--- a/Makefile.mess
+++ b/Makefile.mess
@@ -4,7 +4,7 @@ ifdef LUA_INCDIR
 endif
 
 # OS detection
-uname := $(shell uname -s)
+uname ?= $(shell uname -s)
 
 ifneq ($(uname),Darwin)
 	LDFLAGS += -shared


### PR DESCRIPTION
When cross compiling, "uname" must be set externally since running "uname -s" will return
that of the Build Machine
