### PR TITLE
support custom openssl installations

### DIFF
--- a/Makefile.mess
+++ b/Makefile.mess
@@ -3,6 +3,16 @@ ifdef LUA_INCDIR
 	CFLAGS += -I$(LUA_INCDIR)
 endif
 
+ifdef OPENSSL_DIR
+      CFLAGS += -I$(OPENSSL_DIR)/include
+endif
+
+ifdef CRYPTO_DIR
+      CFLAGS += -I$(CRYPTO_DIR)/include
+endif
+
+
+
 # OS detection
 uname ?= $(shell uname -s)
 

--- a/rockspec/bcrypt-2.1-6.rockspec
+++ b/rockspec/bcrypt-2.1-6.rockspec
@@ -24,6 +24,8 @@ build = {
 
 	build_variables = {
 		LUA_INCDIR = "$(LUA_INCDIR)",
+                OPENSSL_DIR = "$(OPENSSL_DIR)",
+                CRYPTO_DIR = "$(CRYPTO_DIR)", 
 	},
 
 	install = {


### PR DESCRIPTION
Update bcrypt build to honour OPENSSL_DIR & CRYPTO_DIR. Both
variables are commonly recognized by other rocks that need to
work with custom/non-standard openssl installations.