### PR TITLE
c99 for loop compatibility for safebfuns

### DIFF
--- a/src/safebfuns.c
+++ b/src/safebfuns.c
@@ -16,7 +16,7 @@ void explicit_bzero( void * buf, size_t n ) {
 	volatile char * volbuf = ( volatile char * ) buf;
 
 	size_t i;
-	for (i = 0; i < n; i++) {
+	for( i = 0; i < n; i++ ) {
 		volbuf[ i ] = 0;
 	}
 }
@@ -27,7 +27,7 @@ int timingsafe_bcmp( const void * b1, const void * b2, size_t n ) {
 	int result = 0;
 
 	size_t i;
-	for (i = 0; i < n; i++) {
+	for( i = 0; i < n; i++ ) {
 		result |= p1[ i ] ^ p2[ i ];
 	}
 

--- a/src/safebfuns.c
+++ b/src/safebfuns.c
@@ -14,7 +14,9 @@
 
 void explicit_bzero( void * buf, size_t n ) {
 	volatile char * volbuf = ( volatile char * ) buf;
-	for( size_t i = 0; i < n; i++ ) {
+
+	size_t i;
+	for (i = 0; i < n; i++) {
 		volbuf[ i ] = 0;
 	}
 }
@@ -24,7 +26,8 @@ int timingsafe_bcmp( const void * b1, const void * b2, size_t n ) {
 	const unsigned char * p2 = b2;
 	int result = 0;
 
-	for( size_t i = 0; i < n; i++ ) {
+	size_t i;
+	for (i = 0; i < n; i++) {
 		result |= p1[ i ] ^ p2[ i ];
 	}
 


### PR DESCRIPTION
I *think* this will resolve the below compilation error I was getting on CentOS 7.

```
gcc -O2 -fPIC -I/tmp/build/usr/local/openresty/luajit/include/luajit-2.1 -c src/safebfuns.c -o src/safebfuns.o
src/safebfuns.c: In function 'explicit_bzero':
src/safebfuns.c:17:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for( size_t i = 0; i < n; i++ ) {
  ^
src/safebfuns.c:17:2: note: use option -std=c99 or -std=gnu99 to compile your code
src/safebfuns.c: In function 'timingsafe_bcmp':
src/safebfuns.c:27:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for( size_t i = 0; i < n; i++ ) {
  ^

Error: Failed installing dependency: https://luarocks.org/bcrypt-2.2-1.src.rock - Build error: Failed compiling object src/safebfuns.o
```